### PR TITLE
add tasks to parcoords and bump to 0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parcoords
 Title: htmlwidget for d3.js parallel coordinates chart
-Version: 0.1.1
+Version: 0.2
 Authors@R: c( person("Mike", "Bostock", role = c("aut", "cph"), comment =
     "d3.js library in htmlwidgets/lib, http://d3js.org"), person("Kai", "Chang"
     ,role = c( "aut","cph" ), comment = "parallel coordinates reusable chart,

--- a/R/parcoords.R
+++ b/R/parcoords.R
@@ -33,6 +33,14 @@
 #'          \code{ mode = "queue" }
 #' @param rate integer rate at which render will queue; see \href{https://github.com/syntagmatic/parallel-coordinates#parcoords_rate}{}
 #'          for a full discussion and some recommendations
+#' @param tasks a character string or \code{\link[htmlwidgets]{JS}} or list of
+#'          strings or \code{JS} representing a JavaScript function(s) to run
+#'          after the \code{parcoords} has rendered.  These provide an opportunity
+#'          for advanced customization.  Note, the \code{function} will use the
+#'          JavaScript \code{call} mechanism, so within the function, \code{this} will
+#'          be an object with {this.el} representing the containing element of the
+#'          \code{parcoords} and {this.parcoords} representing the \code{parcoords}
+#'          instance.
 #' @param width integer in pixels defining the width of the widget.  Autosizing  to 100%
 #'          of the widget container will occur if \code{ width = NULL }.
 #' @param height integer in pixels defining the height of the widget.  Autosizing to 400px
@@ -107,6 +115,7 @@ parcoords <- function(
   , queue = F
   , mode = F
   , rate = NULL
+  , tasks = NULL
   , width = NULL
   , height = NULL
 ) {
@@ -151,6 +160,17 @@ parcoords <- function(
   # queue=T needs to be converted to render = "queue"
   if (!is.null(queue) && queue) mode = "queue"
 
+  # convert character tasks to htmlwidgets::JS
+  if ( !is.null(tasks) ){
+    tasks = lapply(
+      tasks,
+      function(task){
+        if(!inherits(task,"JS_EVAL")) task <- htmlwidgets::JS(task)
+        task
+      }
+    )
+  }
+
   # forward options using x
   x = list(
     data = data,
@@ -168,6 +188,7 @@ parcoords <- function(
       , width = width
       , height = height
     )
+    , tasks = tasks
   )
 
   # remove NULL options

--- a/inst/htmlwidgets/parcoords.js
+++ b/inst/htmlwidgets/parcoords.js
@@ -131,6 +131,23 @@ HTMLWidgets.widget({
     d3.selectAll("#" + el.id + " svg text")
         .style("font-size","10px");
 
+    // set up a container for tasks to perform after completion
+    //  one example would be add callbacks for event handling
+    //  styling
+    if (!(typeof x.tasks === "undefined") ){
+      if ( (typeof x.tasks.length === "undefined") ||
+       (typeof x.tasks === "function" ) ) {
+         // handle a function not enclosed in array
+         // should be able to remove once using jsonlite
+         x.tasks = [x.tasks];
+      }
+      x.tasks.map(function(t){
+        // for each tasks call the task with el supplied as `this`
+        t.call({el:el,parcoords:parcoords});
+      });
+    }
+
+
     // use expando to attach parcoords to the element
     el.parcoords = parcoords;
     // also attach the parallel coordinates to instance
@@ -145,3 +162,4 @@ HTMLWidgets.widget({
   }
 
 });
+

--- a/man/parcoords.Rd
+++ b/man/parcoords.Rd
@@ -6,8 +6,8 @@
 \usage{
 parcoords(data, rownames = T, color = NULL, brushMode = NULL,
   reorderable = F, axisDots = NULL, margin = NULL, composite = NULL,
-  alpha = NULL, queue = F, mode = F, rate = NULL, width = NULL,
-  height = NULL)
+  alpha = NULL, queue = F, mode = F, rate = NULL, tasks = NULL,
+  width = NULL, height = NULL)
 }
 \arguments{
 \item{data}{data.frame with data to use in the chart}
@@ -51,6 +51,15 @@ progressive rendering.  Usually \code{ queue = T } for very large datasets.}
 
 \item{rate}{integer rate at which render will queue; see \href{https://github.com/syntagmatic/parallel-coordinates#parcoords_rate}{}
 for a full discussion and some recommendations}
+
+\item{tasks}{a character string or \code{\link[htmlwidgets]{JS}} or list of
+strings or \code{JS} representing a JavaScript function(s) to run
+after the \code{parcoords} has rendered.  These provide an opportunity
+for advanced customization.  Note, the \code{function} will use the
+JavaScript \code{call} mechanism, so within the function, \code{this} will
+be an object with {this.el} representing the containing element of the
+\code{parcoords} and {this.parcoords} representing the \code{parcoords}
+instance.}
 
 \item{width}{integer in pixels defining the width of the widget.  Autosizing  to 100%
 of the widget container will occur if \code{ width = NULL }.}


### PR DESCRIPTION
Add a `tasks` argument to `parcoords` to allow an opportunity to provide JavaScript functions for customization after the `parcoords` is rendered.  This is something I try to add to all `htmlwidgets`, but I had not yet added until I discovered in #8 (thx @talgalili).

Bump version to `0.2`.