### PR TITLE
Added dimension title rotation option

### DIFF
--- a/R/parcoords.R
+++ b/R/parcoords.R
@@ -35,6 +35,7 @@
 #' @param rate integer rate at which render will queue; see \href{https://github.com/syntagmatic/parallel-coordinates\#parcoords_rate}{}
 #'          for a full discussion and some recommendations
 #' @param dimensions \code{list} to customize axes dimensions.
+#' @param dimensionTitleRotation \code{integer} amount by which to rotate the dimension titles
 #' @param tasks a character string or \code{\link[htmlwidgets]{JS}} or list of
 #'          strings or \code{JS} representing a JavaScript function(s) to run
 #'          after the \code{parcoords} has rendered.  These provide an opportunity
@@ -129,6 +130,7 @@ parcoords <- function(
   , mode = F
   , rate = NULL
   , dimensions = NULL
+  , dimensionTitleRotation = 0
   , tasks = NULL
   , autoresize = FALSE
   , width = NULL
@@ -206,6 +208,9 @@ parcoords <- function(
     )
   }
 
+  # always rotate in the same direction
+  dimensionTitleRotation <- -abs(dimensionTitleRotation)
+
   # forward options using x
   x <- list(
     data = data,
@@ -223,6 +228,7 @@ parcoords <- function(
       , mode = mode
       , rate = rate
       , dimensions = dimensions
+      , dimensionTitleRotation = dimensionTitleRotation
       , width = width
       , height = height
     )

--- a/inst/examples/examples_dimensions.R
+++ b/inst/examples/examples_dimensions.R
@@ -80,4 +80,5 @@ parcoords(
       tickValues = unique(mtcars$cyl)
     )
   )
+  ,dimensionTitleRotation = 30
 )

--- a/inst/htmlwidgets/lib/parallel-coordinates/d3.parcoords.js
+++ b/inst/htmlwidgets/lib/parallel-coordinates/d3.parcoords.js
@@ -752,7 +752,7 @@ pc.createAxes = function() {
       })
     .append("svg:text")
       .attr({
-        "text-anchor": "middle",
+        "text-anchor": (__.dimensionTitleRotation !== 0 ? "right" : "middle"),
         "y": 0,
         "transform": "translate(0,-5) rotate(" + __.dimensionTitleRotation + ")",
         "x": 0,

--- a/man/parcoords.Rd
+++ b/man/parcoords.Rd
@@ -7,8 +7,9 @@
 parcoords(data = NULL, rownames = T, color = NULL, brushMode = NULL,
   brushPredicate = "and", alphaOnBrushed = NULL, reorderable = F,
   axisDots = NULL, margin = NULL, composite = NULL, alpha = NULL,
-  queue = F, mode = F, rate = NULL, dimensions = NULL, tasks = NULL,
-  autoresize = FALSE, width = NULL, height = NULL, elementId = NULL)
+  queue = F, mode = F, rate = NULL, dimensions = NULL,
+  dimensionTitleRotation = 0, tasks = NULL, autoresize = FALSE,
+  width = NULL, height = NULL, elementId = NULL)
 }
 \arguments{
 \item{data}{data.frame with data to use in the chart}
@@ -57,6 +58,8 @@ progressive rendering.  Usually \code{ queue = T } for very large datasets.}
 for a full discussion and some recommendations}
 
 \item{dimensions}{\code{list} to customize axes dimensions.}
+
+\item{dimensionTitleRotation}{\code{integer} amount by which to rotate the dimension titles}
 
 \item{tasks}{a character string or \code{\link[htmlwidgets]{JS}} or list of
 strings or \code{JS} representing a JavaScript function(s) to run
@@ -223,5 +226,6 @@ parcoords(
       tickValues = unique(mtcars$cyl)
     )
   )
+  ,dimensionTitleRotation = 30
 )
 }


### PR DESCRIPTION
This should take care of #11.  As mentioned in the issue thread, the code base is already there.  Just needed to be adjusted slightly to shift the text anchor so the titles don't encroach into the plot area.  This is a simple rotation... will always rotate in the same direction and shift the text anchor in the same direction.

+1 to the original authors of the code base in this package.  Everything was nicely aligned, clean-looking, and simple.